### PR TITLE
chore(docker): Dockerfiles, compose, make demo target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+**/dist
+**/target
+**/.git
+**/.vscode
+**/.idea
+**/*.log
+**/.env
+**/.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: demo down clean logs qr
+
+URL := http://localhost:80
+
+demo:
+	docker compose up --build -d
+	@echo ""
+	@echo "Snake Arena running at $(URL)"
+	@echo ""
+	@if command -v qrencode >/dev/null 2>&1; then \
+		qrencode -t ANSI '$(URL)'; \
+	else \
+		echo "(install 'qrencode' for QR code: brew install qrencode)"; \
+	fi
+	@echo ""
+	@echo "Open 2 browser tabs at $(URL) to play."
+	@echo "Stop with: make down"
+
+down:
+	docker compose down
+
+clean:
+	docker compose down -v --rmi local
+
+logs:
+	docker compose logs -f
+
+qr:
+	@if command -v qrencode >/dev/null 2>&1; then \
+		qrencode -t ANSI '$(URL)'; \
+	else \
+		echo "$(URL)"; \
+	fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  server:
+    build: ./server
+    container_name: snake-server
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+
+  nginx:
+    build: ./web
+    container_name: snake-web
+    ports:
+      - "80:80"
+    depends_on:
+      server:
+        condition: service_healthy
+    restart: unless-stopped

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM maven:3.9-eclipse-temurin-21 AS build
+WORKDIR /build
+COPY pom.xml .
+RUN mvn -B dependency:go-offline
+COPY src ./src
+RUN mvn -B clean package -DskipTests
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+RUN groupadd -r app && useradd -r -g app app
+COPY --from=build /build/target/snake-arena.jar /app/snake-arena.jar
+USER app
+EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=3s --retries=5 CMD wget -qO- http://localhost:8080/health || exit 1
+ENTRYPOINT ["java", "-jar", "/app/snake-arena.jar"]

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /build
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Runtime stage
+FROM nginx:alpine
+COPY --from=build /build/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+HEALTHCHECK --interval=10s --timeout=3s --retries=5 CMD wget -qO- http://localhost:80/ || exit 1

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,27 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # SPA fallback
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  # WebSocket + HTTP proxy to game server
+  location /ws {
+    proxy_pass http://server:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 3600s;
+  }
+
+  location /api/ {
+    proxy_pass http://server:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
+}


### PR DESCRIPTION
## Summary
- `server/Dockerfile`: multi-stage `maven:3.9-eclipse-temurin-21` → `eclipse-temurin:21-jre`, non-root, exposes 8080, healthcheck on `/health`
- `web/Dockerfile`: `node:20-alpine` (npm ci + vite build) → `nginx:alpine` serving `/usr/share/nginx/html`, exposes 80
- `web/nginx.conf`: SPA fallback + `/ws` WebSocket + `/api/` proxy to `server:8080`
- `docker-compose.yml`: services `server` (8080) and `nginx` (80, depends_on server healthy)
- `Makefile`: `make demo` runs `docker compose up --build -d` and prints URL + QR via `qrencode -t ANSI` (graceful fallback if `qrencode` missing)
- `.dockerignore`

## Dependency status (blocks acceptance)
- **Backend (server/)**: NOT MERGED. Bug report from backend phase: routing error — backend-dev task `nlp-snake-arena-002-backend-7fa2c8` was dispatched to tech-writer agent, refused per CLAUDE.md scope. Re-dispatch needed. `server/Dockerfile` assumes `pom.xml`, `src/`, and `snake-arena.jar` artifact name.
- **Frontend (web/)**: PR #2 open on `feat/web` branch. `web/Dockerfile` assumes `package.json` + `npm run build` produces `dist/` (verified against `feat/web` tree).

`make demo` from clean clone will FAIL until backend PR + frontend PR #2 are merged into master. Docker config itself is independent and can be reviewed/merged in any order.

## Test plan
- [ ] After backend re-dispatch + frontend PR #2 merge: `git clone` → `make demo` → `docker compose up` succeeds in <60s
- [ ] http://localhost:80 serves lobby
- [ ] 2 browser tabs can join + see each other move
- [ ] Server survives round-end → next round
- [ ] `qrencode` absent → URL printed, no failure

<!-- ARTIFACT:pull_request pr_url=PLACEHOLDER pr_number=PLACEHOLDER -->